### PR TITLE
fix(context): исправил ошибку конструкторов Массива

### DIFF
--- a/engine/src/main/java/com/github/otymko/jos/runtime/context/type/collection/V8Array.java
+++ b/engine/src/main/java/com/github/otymko/jos/runtime/context/type/collection/V8Array.java
@@ -45,41 +45,31 @@ public class V8Array extends ContextValue implements IndexAccessor, CollectionIt
     }
 
     /**
-     * Создать новый массив на основании фиксированного массива или числа.
+     * Создать новый массив на основании списка значений.
      *
-     * @param value Фиксированный массив или число.
+     * @param values список значений.
      */
     @ContextConstructor
-    public static IValue createByValue(IValue value) {
-        if (value.getDataType() == DataType.NUMBER) {
-            return new V8Array(value);
-        } else if (value instanceof V8FixedArray) {
-            return new V8Array((V8FixedArray) value);
+    public static IValue createByValues(IValue... values) {
+        IValue firstValue = values[0];
+        if (firstValue instanceof V8FixedArray) {
+            return new V8Array((V8FixedArray)firstValue);
+        } else if (firstValue.getDataType() == DataType.NUMBER) {
+            return new V8Array(values);
         }
 
         throw new IllegalArgumentException();
     }
 
-    /**
-     * Создать новый массив на основании списка чисел.
-     *
-     * @param numbers список чисел.
-     */
-    @ContextConstructor
-    public static IValue createByValues(IValue... numbers) {
-        return new V8Array(numbers);
-    }
-
     private V8Array(V8FixedArray array) {
-        values = List.copyOf(array.getValues());
+        values = new ArrayList<>(array.getValues());
     }
     private V8Array() {
         values = new ArrayList<>();
     }
 
     private V8Array(IValue... numbers) {
-        values = new ArrayList<>();
-        values.addAll(Arrays.asList(numbers));
+        values = new ArrayList<>(Arrays.asList(numbers));
     }
 
     @Override

--- a/engine/src/main/java/com/github/otymko/jos/runtime/context/type/collection/V8FixedArray.java
+++ b/engine/src/main/java/com/github/otymko/jos/runtime/context/type/collection/V8FixedArray.java
@@ -19,6 +19,7 @@ import com.github.otymko.jos.runtime.machine.info.ContextInfo;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.github.otymko.jos.runtime.machine.context.ContextValueConverter.convertValue;
@@ -39,7 +40,7 @@ public class V8FixedArray extends ContextValue implements IndexAccessor, Collect
     }
 
     private V8FixedArray(V8Array array) {
-        values = List.copyOf(array.getValues());
+        values = new ArrayList<>(array.getValues());
     }
 
     @ContextMethod(name = "Количество", alias = "Count")


### PR DESCRIPTION
Проблема:
В рантайме неоднозначные конструкторы у класса V8Array (IValue vargs).

Решение:
Развести создание V8Array через условие.

Closed: #186 